### PR TITLE
VGS Collect Add card icon to style examples [ch30907]

### DIFF
--- a/styles-examples/payment-form-custom.js
+++ b/styles-examples/payment-form-custom.js
@@ -21,7 +21,10 @@ payment_form.field('#payment-cc-number .field-space', {
   type: 'card-number',
   name: 'card.number',
   validations: ['required', 'validCardNumber'],
-  css: styles,
+  showCardIcon: {
+    right: '10px',
+  },
+  css: Object.assign(styles, {paddingRight: '45px'}),
 });
 
 payment_form.field('#payment-cc-cvc .field-space', {


### PR DESCRIPTION
Fixes [30907](https://app.clubhouse.io/vgs/story/30907/vgs-collect-add-card-icon-to-style-examples-page)

- Added card brand icon to en example